### PR TITLE
Use same commit message as mono repo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,6 +51,8 @@ note "Cleaning destination repository of old files"
 find "$CLONE_DIR" | grep -v "^$CLONE_DIR/\.git" | grep -v "^$CLONE_DIR$" | xargs rm -rf # delete all files (to handle deletions)
 ls -la "$CLONE_DIR"
 
+COMMIT_MESSAGE=$(git show -s --format=%B "$GITHUB_SHA")
+
 note "Copying contents to git repo"
 
 cp -r "$PACKAGE_DIRECTORY"/* "$CLONE_DIR"
@@ -58,8 +60,6 @@ cd "$CLONE_DIR"
 ls -la
 
 note "Adding git commit"
-
-COMMIT_MESSAGE=$(git --git-dir "$PACKAGE_DIRECTORY" show -s --format=%B "$GITHUB_SHA")
 
 git add .
 git status

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,8 +59,7 @@ ls -la
 
 note "Adding git commit"
 
-ORIGIN_COMMIT="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
-COMMIT_MESSAGE="${COMMIT_MESSAGE/ORIGIN_COMMIT/$ORIGIN_COMMIT}"
+COMMIT_MESSAGE=$(git --git-dir "$PACKAGE_DIRECTORY" show -s --format=%B "$GITHUB_SHA")
 
 git add .
 git status


### PR DESCRIPTION
Not sure if this works, but I really would like to have the original commit message. Having a split repo filled with same commit messages makes it hard to understand what is what.